### PR TITLE
Fixed homepage: s/progress-bar/progressbar/

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "zf2",
         "progressbar"
     ],
-    "homepage": "https://github.com/zendframework/zend-progress-bar",
+    "homepage": "https://github.com/zendframework/zend-progressbar",
     "autoload": {
         "psr-4": {
             "Zend\\ProgressBar\\": "src/"


### PR DESCRIPTION
Corrects the homepage in `composer.json` to reference `progressbar` instead of `progress-bar`.
