### PR TITLE
Updated dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ matrix:
     - php: 7
     - php: hhvm 
   allow_failures:
-    - php: 7
     - php: hhvm
 
 notifications:

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
         }
     },
     "require": {
-        "php": ">=5.5",
-        "zendframework/zend-stdlib": "~2.5"
+        "php": "^5.5 || ^7.0",
+        "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
-        "zendframework/zend-json": "~2.5",
-        "zendframework/zend-session": "~2.5",
+        "zendframework/zend-json": "^2.6.1",
+        "zendframework/zend-session": "^2.6.2",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },


### PR DESCRIPTION
- Allow PHP 5.5+ or 7.0+
- Allow either 2.7+ or 3.0+ versions of zend-stdlib
- Pin dev requirements to known stable, forwards compatible versions
